### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Repository to accompany the YouTube series
 
 Requirements
 ------------
-- [PHP 8.0 or higher](https://www.php.net/downloads.php)
+- [PHP 8.1 or higher](https://www.php.net/downloads.php)
 - [Composer](https://getcomposer.org/)
 - [Symfony CLI](https://symfony.com/download)
 <!-- - [Docker](https://www.docker.com/) -->


### PR DESCRIPTION
This project has a dependency `"symfony/polyfill-php81": "*"`
which requires PHP 8.1
Having local machine PHP version older than this will result in error when installing composer dependecies.